### PR TITLE
fixes check for what type future_status returns

### DIFF
--- a/prototype/src/rclcpp/include/rclcpp/client/client.hpp
+++ b/prototype/src/rclcpp/include/rclcpp/client/client.hpp
@@ -51,7 +51,7 @@ namespace rclcpp
             typename ROSService::Response::ConstPtr call(typename ROSService::Request &req)
             {
                 shared_future f = this->async_call(req);
-#if ((__GNUC__ == 4) && (__GNUC_MINOR__ < 7))
+#if (!__clang__ && (__GNUC__ == 4) && (__GNUC_MINOR__ < 7))
                 // NOTE The version (4.6) of GCC that ships with Ubuntu 12.04
                 // is broken, wait_for should return a std::future_status,
                 // according to the C++11 spec, not a bool as is GCC's case


### PR DESCRIPTION
When I try the current master branch on my Mac I get:

```
In file included from /Users/william/devel/ros_dds/prototype/src/rclcpp_examples/src/add_two_ints_client.cpp:1:
In file included from /Users/william/devel/ros_dds/prototype/src/rclcpp/include/rclcpp/rclcpp.hpp:8:
In file included from /Users/william/devel/ros_dds/prototype/src/rclcpp/include/rclcpp/node/node.hpp:19:
/Users/william/devel/ros_dds/prototype/src/rclcpp/include/rclcpp/client/client.hpp:66:28: error: assigning to 'bool' from incompatible type 'std::__1::future_status'
                    status = f.wait_for(std::chrono::milliseconds(100));
                           ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/william/devel/ros_dds/prototype/src/rclcpp_examples/src/add_two_ints_client.cpp:28:29: note: in instantiation of member function
      'rclcpp::client::Client<rclcpp_examples::AddTwoInts>::call' requested here
    auto response = client->call(req);
                            ^
1 error generated.
```

This pull request fixes that by changing the `#ifdef` block to consider `__clang__`.
